### PR TITLE
fix(shared/search): add 'any' to prevent TS7005 and TS7006 error mess…

### DIFF
--- a/lib/angular2/shared/search.params.ejs
+++ b/lib/angular2/shared/search.params.ejs
@@ -17,8 +17,8 @@ export class JSONSearchParams {
         return this._usp;
     }
 
-    private _JSON2URL(obj: any, parent) {
-        var parts = [];
+    private _JSON2URL(obj: any, parent: any) {
+        var parts: any = [];
         for (var key in obj)
         parts.push(this._parseParam(key, obj[key], parent));
         return parts.join('&');


### PR DESCRIPTION
I got following errors in Angular2 Quickstart project:

`sdk/services/search.params.ts(20,33): error TS7006: Parameter 'parent' implicitly has an 'any' type.
sdk/services/search.params.ts(21,13): error TS7005: Variable 'parts' implicitly has an 'any[]' type.`

This commit fixed it