### PR TITLE
optional parameters part of classes

### DIFF
--- a/lib/angular2/shared/model.ejs
+++ b/lib/angular2/shared/model.ejs
@@ -16,7 +16,7 @@ export class <%- modelName %> implements <%- modelName %>Interface {
   /**
    * <%- meta.description %>
    */<% } %>
-  <%- property %><%= meta.required ? '' : '?' -%>: <%- getModelType(meta.type) %>;
+  <%- property -%>: <%- getModelType(meta.type) -%>;
   <%
   } // for property in model.properties -%>
 }

--- a/lib/angular2/shared/model.ejs
+++ b/lib/angular2/shared/model.ejs
@@ -16,7 +16,7 @@ export class <%- modelName %> implements <%- modelName %>Interface {
   /**
    * <%- meta.description %>
    */<% } %>
-  <% if (meta.required) { %><%- property %><%= meta.required ? '' : '?' -%>: <%- getModelType(meta.type) %>; <%} %>
+  <%- property %><%= meta.required ? '' : '?' -%>: <%- getModelType(meta.type) %>;
   <%
   } // for property in model.properties -%>
 }


### PR DESCRIPTION
I am wondering why optional parameters cannot be part of a class? Else whenever I like to upsert a new entitiy with optional parameter, my strict error checking complains about the fact that attribute doesn't exist.

```js
let entity = new Entity();
entity.required = "this works fine";
entity.optional = "this wont work";
this.entityApi.upsert(entity)
```

```bash
error TS2339: Property 'optional' does not exist on type 'Entity'.
```

So any good idea why we shouldn't merge this ?