### PR TITLE
Using LoopBackFilterInterface in favor of LoopBackFilter for find methods

### DIFF
--- a/lib/angular2/shared/services/custom/service.ejs
+++ b/lib/angular2/shared/services/custom/service.ejs
@@ -8,7 +8,7 @@ import {
   BaseLoopBackApi,
 } from '../core/index';
 import {
-  LoopBackFilter,
+  LoopBackFilterInterface,
   <%-: modelName %>
 } from '../../models/index';
 import { LoopBackConfig } from '../../lb.config';
@@ -76,7 +76,7 @@ if (httpVerb == 'POST' || httpVerb == 'PUT' || httpVerb == 'PATCH') {
         routeParams.push(param);
       }
       -%><%= param.arg %>: <% if (param.type === 'object') {
-        %><%= param.arg === 'filter' ? 'LoopBackFilter' : 'any' -%><%
+        %><%= param.arg === 'filter' ? 'LoopBackFilterInterface' : 'any' -%><%
       }
       else {
         %><%= param.type !== 'AccessToken' && !postData ? param.type : 'any' %><%
@@ -147,7 +147,7 @@ if (model.isUser && methodName === 'login') { %>
         //urlParams.push(param);
       }
       -%><% if (param.arg !== 'fk') { -%><%= param.arg %>: <% if (param.type === 'object') {
-        %><%= param.arg === 'filter' ? 'LoopBackFilter' : 'any' -%><%
+        %><%= param.arg === 'filter' ? 'LoopBackFilterInterface' : 'any' -%><%
       }
       else {
         %><%= param.type !== 'AccessToken' && !postData ? param.type : 'any' %><%

--- a/tests/angular2/src/app/shared/sdk/services/custom/User.ts
+++ b/tests/angular2/src/app/shared/sdk/services/custom/User.ts
@@ -594,9 +594,7 @@ export class UserApi extends BaseLoopBackApi {
       credentials: credentials,
       include: include
     };
-    let postBody  : any = {
-      credentials: credentials
-    };
+    let postBody  : any = credentials;
     let result = this.request(method, url, routeParams, urlParams, postBody)
       .share();
       result.subscribe(


### PR DESCRIPTION
After upgrading from beta16 to rc.5 I got plenty of following errors:

```
error TS2345: Argument of type '{ where: { id: any; }; }' is not assignable to parameter of type 'LoopBackFilter'.
Property 'fields' is missing in type '{ where: { id: any; }; }'

```

Expecting LoopBackFilterInterface instead of LoopBackFilter in functions corrected this.